### PR TITLE
Update MultiToolEquip.lua

### DIFF
--- a/src/Octagon/Server/Detections/NonPhysics/MultiToolEquip.lua
+++ b/src/Octagon/Server/Detections/NonPhysics/MultiToolEquip.lua
@@ -122,8 +122,9 @@ function MultiToolEquip._initSignals()
 		for _, tool in pairs(playerEquippedToolsData.Tools) do
 			-- Handle edge case where the tool is immediately destroyed after being parented:
 			if tool.Parent == player.Character then
-				task.wait()
-				tool.Parent = player.Backpack
+				task.defer(function()
+					tool.Parent = player.Backpack
+				end)
 			end
 		end
 


### PR DESCRIPTION
Changed task.wait to task.defer.

Using task.defer instead of task.wait when you can is always better.

When wanting to fix bugs with parenting you should use task.defer instead of task.wait.